### PR TITLE
Allow make clean to run without BOARD set

### DIFF
--- a/make.mk
+++ b/make.mk
@@ -2,7 +2,12 @@
 BUILD = ./build
 BIN = firmware
 
-include $(GOSSAMER_PATH)/boards/$(BOARD)/board.mk
+# Only include board.mk if BOARD is set and not cleaning
+ifeq (,$(filter clean,$(MAKECMDGOALS)))
+  ifdef BOARD
+    include $(GOSSAMER_PATH)/boards/$(BOARD)/board.mk
+  endif
+endif
 
 ##############################################################################
 .PHONY: all directory clean size

--- a/rules.mk
+++ b/rules.mk
@@ -50,10 +50,18 @@ $(SUBMODULES):
 
 ifeq ($(DFU), 1)
 install:
+	@if [ ! -f $(BUILD)/$(BIN).dfu ]; then \
+		echo "\033[0;31m\033[1mError: Firmware not found. Please run 'make BOARD=<board_name>' first to build the firmware.\033[0m"; \
+		exit 1; \
+	fi
 	@$(DFU_UTIL) -D $(BUILD)/$(BIN).dfu
 	@echo "\033[0;97m\033[1mRemember to press RESET to run the newly installed code!\033[0m"
 else
 install:
+	@if [ ! -f $(BUILD)/$(BIN).uf2 ]; then \
+		echo "\033[0;31m\033[1mError: Firmware not found. Please run 'make BOARD=<board_name>' first to build the firmware.\033[0m"; \
+		exit 1; \
+	fi
 	@$(UF2) -D $(BUILD)/$(BIN).uf2
 endif
 


### PR DESCRIPTION
Make it possible to run `make clean` without setting the BOARD variable. The board-specific makefile is now only included for non-clean targets. Cleaning doesn’t need any board info, so this should make the workflow a bit smoother.

Also made `make install` work without BOARD parameter

Right now you have to specify a BOARD when running `make install`, which is annoying if you just want to install firmware that's already been built. This change makes `make install` check if the firmware files exist first, and if they don't, it gives you an error message telling you to build first.

## What changed
- `make install` no longer requires BOARD to be set
- If firmware isn't built yet, you get a clear error message instead of a cryptic build failure
- All the existing workflows still work exactly the same

## Why this is better
You can now do things like:
- `make install` (if you already built firmware)
- `make BOARD=feather_m0 && make install` (build and install)
- `make BOARD=feather_m0` (build only)
- `make install` (install later, no BOARD needed)