### PR TITLE
Make TIMESET work on Windows

### DIFF
--- a/make.mk
+++ b/make.mk
@@ -205,11 +205,20 @@ DEFINES += \
 #  day = BUILD_YEAR, BUILD_MONTH and BUILD_DAY are defined
 #  minute = BUILD_YEAR, BUILD_MONTH, BUILD_DAY, BUILD_HOUR and BUILD_MINUTE are defined
 ifdef TIMESET
+ifeq ($(DETECTED_OS), WINDOWS)
+CURRENT_YEAR := $(shell powershell -Command "[System.DateTime]::Now.Year - 2020")
+CURRENT_MONTH := $(shell powershell -Command "[System.DateTime]::Now.Month")
+CURRENT_DAY := $(shell powershell -Command "[System.DateTime]::Now.Day")
+CURRENT_HOUR := $(shell powershell -Command "[System.DateTime]::Now.Hour")
+CURRENT_MINUTE := $(shell powershell -Command "[System.DateTime]::Now.Minute")
+else
+# Unix/Linux/macOS
 CURRENT_YEAR := $(shell echo $$(($(shell date +"%Y") - 2020)))
 CURRENT_MONTH := $(shell date +"%-m")
 CURRENT_DAY := $(shell date +"%-d")
 CURRENT_HOUR := $(shell date +"%-H")
 CURRENT_MINUTE := $(shell date +"%-M")
+endif
 ifeq ($(TIMESET), year)
 CFLAGS += -DBUILD_YEAR=$(CURRENT_YEAR)
 else ifeq ($(TIMESET), day)


### PR DESCRIPTION
Powershell doesn't have `date`, so use the .NET function `System.DateTime` instead.