### PR TITLE
Preciser dependency tracking

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -107,4 +107,4 @@ $(BUILD)/%.d: %.c | directory
 	@$(CC) $(CFLAGS) -MM -MT $(BUILD)/$(notdir $(<:.c=.o)) $< > $@
 
 
--include $(wildcard $(DEPFILES))
+-include $(DEPFILES)

--- a/rules.mk
+++ b/rules.mk
@@ -45,7 +45,7 @@ $(BUILD)/$(BIN).dfu: $(BUILD)/$(BIN).elf
 	@$(DFU_CONV) $^ $@
 
 # Emscripten HTML target
-$(BUILD)/$(BIN).html: $(OBJS)
+$(BUILD)/$(BIN).html: $(OBJS) watch-library/simulator/shell.html
 	@echo HTML $@
 	@$(CC) $(LDFLAGS) $(OBJS) $(LIBS) -o $@ \
 		-s ASYNCIFY=1 \


### PR DESCRIPTION
This should fix #5: editing `movement_config.h' allows a new build to recompile the needed files.

I also adjusted the html target to rebuild after an edit to the html file.