### PR TITLE
Added an I2C timeout to how fast each byte can be read

### DIFF
--- a/peripherals/i2c.c
+++ b/peripherals/i2c.c
@@ -16,6 +16,7 @@
 #define BUSSTATE_IDLE 1
 #define BUSSTATE_OWNER 2
 #define BUSSTATE_BUSY 3
+#define BUS_TIMEOUT 50000
 
 #if defined(I2C_SERCOM)
 
@@ -109,7 +110,7 @@ i2c_result_t i2c_write_instance(uint8_t sercom, uint8_t address, uint8_t* data, 
 
     /* This can hang forever, so put a timeout on it. */
     size_t w = 0;
-    for (; w < 100000; w++) {
+    for (; w < BUS_TIMEOUT; w++) {
         if (SERCOM_Peripherals[sercom].sercom->I2CM.INTFLAG.bit.MB) {
             break;
         }
@@ -128,10 +129,14 @@ i2c_result_t i2c_write_instance(uint8_t sercom, uint8_t address, uint8_t* data, 
         /* Send data and wait for TX complete. */
         SERCOM_Peripherals[sercom].sercom->I2CM.DATA.bit.DATA = data[i];
 
+        w = 0;
         while (!SERCOM_Peripherals[sercom].sercom->I2CM.INTFLAG.bit.MB) {
             /* Check for loss of arbitration or a bus error. We can't continue if those happen. */
             /* BUSERR is set in addition to ARBLOST if arbitration is lost, so just check that one. */
             if (SERCOM_Peripherals[sercom].sercom->I2CM.STATUS.bit.BUSERR) {
+                return I2C_RESULT_ERR_BUSERR;
+            }
+            if (++w >= BUS_TIMEOUT) {
                 return I2C_RESULT_ERR_BUSERR;
             }
         }
@@ -144,8 +149,12 @@ i2c_result_t i2c_write_instance(uint8_t sercom, uint8_t address, uint8_t* data, 
 
     /* Send STOP command. */
     SERCOM_Peripherals[sercom].sercom->I2CM.CTRLB.bit.CMD = 3;
-    while (SERCOM_Peripherals[sercom].sercom->I2CM.SYNCBUSY.bit.SYSOP) {};
-
+    w = 0;
+    while (SERCOM_Peripherals[sercom].sercom->I2CM.SYNCBUSY.bit.SYSOP) {
+        if (++w >= BUS_TIMEOUT) {
+            return I2C_RESULT_ERR_BUSERR;
+        }
+    }
     return I2C_RESULT_SUCCESS;
 }
 
@@ -167,7 +176,7 @@ i2c_result_t i2c_read_instance(uint8_t sercom, uint8_t address, uint8_t* data, s
 
     /* This can hang forever, so put a timeout on it. */
     size_t w = 0;
-    for (; w < 100000; w++) {
+    for (; w < BUS_TIMEOUT; w++) {
         if (SERCOM->I2CM.INTFLAG.bit.SB) {
             break;
         }
@@ -184,13 +193,23 @@ i2c_result_t i2c_read_instance(uint8_t sercom, uint8_t address, uint8_t* data, s
     /* Receive data bytes. */
     for (size_t i = 0; i < len; i++) {
         /* Receive data and wait for RX complete. */
+        w = 0;
         data[i] = SERCOM->I2CM.DATA.bit.DATA;
-        while (!SERCOM->I2CM.INTFLAG.bit.SB);
+        while (!SERCOM->I2CM.INTFLAG.bit.SB) {
+            if (++w >= BUS_TIMEOUT) {
+                return I2C_RESULT_ERR_BUSERR;
+            }
+        }
     }
 
     /* Send STOP command, NACK */
     SERCOM->I2CM.CTRLB.reg |= SERCOM_I2CM_CTRLB_ACKACT | SERCOM_I2CM_CTRLB_CMD(3);
-    while (SERCOM->I2CM.SYNCBUSY.bit.SYSOP) {};
+    w = 0;
+    while (SERCOM->I2CM.SYNCBUSY.bit.SYSOP) {
+        if (++w >= BUS_TIMEOUT) {
+            return I2C_RESULT_ERR_BUSERR;
+        }
+    }
 
     return I2C_RESULT_SUCCESS;
 }


### PR DESCRIPTION
In testing for a step counter, i was reading 25 samples a second.
Each sample is 6 bytes, so that's `150 bytes.
Since I do it in between ticks, I run into an issue if I read the bytes slower than 7ms.
Under normal cases, that should not be a large issue, but I think I'm seeing battery-depletion affect it.

My step counter code chugged current once every 4 seconds, it drained the battery from 2.91 to 2.85V in 2 hours, which I think led to the slowdown of the I2C comms.

While the slowdown of the I2C message so rapidly was caused by my code, the watch's failure-mode was to completely freeze. It would be seen draining the battery at above 100uA in this  state and required taking apart the case to reset it.
So I think this fix isn't urgent, but important, since the failure is so bad when someone uses the accelerometer logic as advertised and have an old battery.


I never probed the I2C pins, so I do not have a ground-truth on whether the I2C is slower, but from testing with and without this code, I am seeing that this avoids my freezing.

I chose an I2C timeout of 50,000 because:

I'm assuming 10 instructions per while loop.
SAM L22 is 32MHz, so at 10 instructions per while loop, it's a timeout of 15.625ms.
This timeout is enough for reading the accelerometer at 12.5Hz without issue, which is what I'm using in my application.


There likely is a better solution than this, but it's working for me and is important enough to flag as a concern in the gossamer code, so i still want to share this fix.
Likely, a better fix is to have a single counter throughout the whole function that is set to being 80% of the tick frequency...or something else that I cannot consider.