### PR TITLE
Added eic_get_channel_for_pin

### DIFF
--- a/common/eic.h
+++ b/common/eic.h
@@ -58,6 +58,12 @@ void eic_enable(void);
  */
 bool eic_is_enabled(void);
 
+/** @brief Finds the EIC channel number associated with the pin that is mapped to a pin.
+  * @param pin The external interrupt pin you wish to configure — use HAL_GPIO_xxx_PIN() macro.
+  * @return the EIC channel number associated with the pin, or -1 if the pin is not an interrupt pin.
+  */
+int8_t eic_get_channel_for_pin(uint8_t pin);
+
 /** @brief Configures an external interrupt on one of the external interrupt pins.
   * @details This function configures the interrupt channel with the specified trigger, but it does not
   *          set pin direction, mux or pull; you must set up the pin yourself. This function also does

--- a/dummy/peripherals/eic.c
+++ b/dummy/peripherals/eic.c
@@ -39,6 +39,10 @@ bool eic_is_enabled(void) {
     return true;
 }
 
+int8_t eic_get_channel_for_pin(uint8_t pin) {
+    return 0;
+}
+
 int8_t eic_configure_pin(const uint8_t pin, eic_interrupt_trigger_t trigger, bool filten) {
     return 0;
 }

--- a/peripherals/eic.c
+++ b/peripherals/eic.c
@@ -100,6 +100,14 @@ bool eic_is_enabled(void) {
     return CTRLREG.bit.ENABLE;
 }
 
+int8_t eic_get_channel_for_pin(uint8_t pin) {
+    int8_t channel = _eic_pin_to_channel[pin >> 5][pin & 0x1F];
+    if (channel < 0) {
+        return -1;
+    }
+    return channel;
+}
+
 int8_t eic_configure_pin(const uint8_t pin, eic_interrupt_trigger_t trigger, bool filten) {
     uint16_t port = pin >> 5;
     int8_t channel = _eic_pin_to_channel[port][pin & 0x1F];


### PR DESCRIPTION
I want to be able to turn off interrupts, which requires the channel info.

In the sensorwatch code, i included:

```
void watch_unregister_interrupt_callback(const uint8_t pin) {
    int8_t channel = eic_get_channel_for_pin(pin);
    if (channel >= 0 && channel < 16) {
        eic_disable_interrupt(pin);
        eic_callbacks[channel] = NULL;
    }
}
```

And that needs the channel info. 