### PR TITLE
Add a timeout to the byte read loop in i2c_read_instance()

### DIFF
--- a/peripherals/i2c.c
+++ b/peripherals/i2c.c
@@ -185,7 +185,13 @@ i2c_result_t i2c_read_instance(uint8_t sercom, uint8_t address, uint8_t* data, s
     for (size_t i = 0; i < len; i++) {
         /* Receive data and wait for RX complete. */
         data[i] = SERCOM->I2CM.DATA.bit.DATA;
-        while (!SERCOM->I2CM.INTFLAG.bit.SB);
+        /* This can hang forever, so put a timeout on it. */
+        size_t w = 0;
+        for (; w < 100000; w++) {
+            if (SERCOM->I2CM.INTFLAG.bit.SB) {
+                break;
+            }
+        }
     }
 
     /* Send STOP command, NACK */


### PR DESCRIPTION
The loop in i2c_read_instance() that reads each byte spins on the SB flag
with no timeout:

    for (size_t i = 0; i < len; i++) {
        data[i] = SERCOM->I2CM.DATA.bit.DATA;
        while (!SERCOM->I2CM.INTFLAG.bit.SB);   // never returns if SB never asserts
    }

If the device stops driving the bus in the middle of a read, for example a
stuck bus, a clock stretch, or a NACK, SB never asserts and the call hangs
forever, taking the firmware with it.

This adds the same iteration limit (100000) that the address phase in this
same function already uses, so a bad transaction gives up instead of
wedging the bus.
